### PR TITLE
Live Leaderboard Updates & Add retries on async (working)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -14,7 +14,12 @@ SQLALCHEMY_DATABASE_URL_ASYNC = f"postgresql+asyncpg://{CREDENTIALS['database_us
                           f"@{CREDENTIALS['database_host']}/{CREDENTIALS['database_name']}"
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
-engine_async = create_async_engine(SQLALCHEMY_DATABASE_URL_ASYNC)
+engine_async = create_async_engine(SQLALCHEMY_DATABASE_URL_ASYNC,
+    pool_size=20,                 # Max number of connections in the pool
+    max_overflow=10,               # Extra connections that can be created beyond pool_size
+    pool_timeout=30,               # Time to wait before timing out when requesting a connection
+    pool_recycle=1800              # Recycle connections after 30 minutes to avoid stale connections
+)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 SessionLocalAsync = sessionmaker(

--- a/app/database.py
+++ b/app/database.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from app.utils.general import read_environment_variables
 
@@ -9,9 +10,20 @@ CREDENTIALS: dict[str, any] = read_environment_variables()
 
 SQLALCHEMY_DATABASE_URL = f"postgresql://{CREDENTIALS['database_username']}:{CREDENTIALS['database_password']}" \
                           f"@{CREDENTIALS['database_host']}/{CREDENTIALS['database_name']}"
+SQLALCHEMY_DATABASE_URL_ASYNC = f"postgresql+asyncpg://{CREDENTIALS['database_username']}:{CREDENTIALS['database_password']}" \
+                          f"@{CREDENTIALS['database_host']}/{CREDENTIALS['database_name']}"
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
+engine_async = create_async_engine(SQLALCHEMY_DATABASE_URL_ASYNC)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+SessionLocalAsync = sessionmaker(
+    bind=engine_async,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autoflush=False
+)
+
 
 Base = declarative_base()
 Base.metadata.create_all(bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -37,10 +37,11 @@ app.add_middleware(
 @app.on_event("startup")
 async def start_background_tasks():
     asyncio.create_task(uya_online_tracker.refresh_token())
+    asyncio.create_task(uya_online_tracker.update_recent_stat_changes())
     asyncio.create_task(uya_online_tracker.poll_active_online())
     asyncio.create_task(dl_online_tracker.refresh_token())
+    #asyncio.create_task(dl_online_tracker.update_recent_stat_changes())    # Will work once DL middleware is updated
     asyncio.create_task(dl_online_tracker.poll_active_online())
-
 
 # Add sub-APIs.
 app.include_router(deadlocked_stats_router)

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -1,0 +1,47 @@
+import functools
+import asyncio
+import logging
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+stream_handler.setFormatter(formatter)
+logger.addHandler(stream_handler)
+
+def retry_async(retries=3, delay=2, exception_types=(Exception,)):
+    """
+    A decorator to automatically retry a function in case of specified exceptions.
+
+    :param retries: Number of retry attempts.
+    :param delay: Delay between retries in seconds.
+    :param exception_types: Tuple of exception types to catch and retry on.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            attempt = 0
+            while attempt < retries:
+                try:
+                    return await func(*args, **kwargs)
+                except exception_types as e:
+                    attempt += 1
+                    logger.warning(f"Function '{func.__name__}' failed on attempt {attempt}/{retries}: {str(e)}")
+
+                    # Try to find session in args: update_player_vanilla_stats_async
+                    session = None
+                    for arg in args:
+                        if isinstance(arg, AsyncSession):
+                            session = arg
+                            logger.warning(f"Function '{func.__name__}' rolling back session!")
+                            await session.rollback()  
+                            break
+
+                    if attempt < retries:
+                        await asyncio.sleep(delay)
+                    else:
+                        raise
+        return wrapper
+    return decorator

--- a/app/utils/query_helpers.py
+++ b/app/utils/query_helpers.py
@@ -6,6 +6,8 @@ from sqlalchemy.future import select
 from sqlalchemy import literal_column, func, inspect
 from sqlalchemy.orm import Session, Query, DeclarativeBase, selectinload
 
+from app.utils.database import retry_async
+
 from app.models.dl import (
     DeadlockedPlayer,
     DeadlockedOverallStats,
@@ -83,7 +85,7 @@ def update_player_vanilla_stats(
         session.add(player)
         session.commit()
 
-
+@retry_async(retries=3, delay=2)
 async def update_player_vanilla_stats_async(
     game: str,
     session: Session,

--- a/app/utils/query_helpers.py
+++ b/app/utils/query_helpers.py
@@ -1,8 +1,10 @@
 import functools
 from typing import Optional
+import logging
 
-from sqlalchemy import literal_column, func
-from sqlalchemy.orm import Session, Query, DeclarativeBase
+from sqlalchemy.future import select
+from sqlalchemy import literal_column, func, inspect
+from sqlalchemy.orm import Session, Query, DeclarativeBase, selectinload
 
 from app.models.dl import (
     DeadlockedPlayer,
@@ -31,6 +33,15 @@ from app.models.uya import (
 from app.schemas.schemas import StatOffering
 from horizon.parsing.deadlocked_stats import vanilla_stats_map, custom_stats_map
 from horizon.parsing.uya_stats import uya_vanilla_stats_map
+from horizon.middleware_api import get_account_basic_stats_async
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+stream_handler.setFormatter(formatter)
+logger.addHandler(stream_handler)
 
 
 def update_player_vanilla_stats(
@@ -71,6 +82,74 @@ def update_player_vanilla_stats(
 
         session.add(player)
         session.commit()
+
+
+async def update_player_vanilla_stats_async(
+    game: str,
+    session: Session,
+    player_id: int | str,
+    wide_stats: list[int],
+    protocol: str,
+    host: str,
+    app_id: str,
+    token: str,
+) -> None:
+    if game == 'dl':
+        player_class = DeadlockedPlayer
+        stats_map = vanilla_stats_map
+    elif game == 'uya':
+        player_class = UyaPlayer
+        stats_map = uya_vanilla_stats_map
+
+    assert len(wide_stats) == 100, "The provided wide stats length is not 100, please validate your input."
+
+    # Need to add these to options to prevent lazy loading which fails with async
+    mapper = inspect(player_class)
+    options = []
+
+    # Dynamically add selectinload for each relationship
+    for rel in mapper.relationships:
+        relationship_attribute = getattr(player_class, rel.key)
+        options.append(selectinload(relationship_attribute))
+
+    logger.debug(f"update_player_vanilla_stats_async: {player_id} Got options: {options}")
+    # Create a select statement with the filter condition
+    stmt = select(player_class).options(*options).filter_by(horizon_id=int(player_id))
+    # Execute the statement asynchronously
+    result = await session.execute(stmt)
+    # Fetch the first result
+    player = result.scalars().first()
+
+    logger.debug(f"update_player_vanilla_stats_async: Got player: {player}")
+
+    if player is None: # Player doesn't exist in db. Add it
+        player_info: dict = await get_account_basic_stats_async(protocol, host, player_id, app_id, token)
+
+        if player_info == {}:
+            logger.warning(f"update_player_vanilla_stats_async: No information found in prod db querying: {protocol}://{host} {player_id}, {app_id}")
+            return
+        logger.debug(f"update_player_vanilla_stats_async: Creating user: {player_id} {player_info['AccountName']}")
+
+        player = player_class(username=player_info["AccountName"], horizon_id=player_id)
+        session.add(player)
+        await session.flush()
+        await session.commit()
+
+        # TODO This has a lot of code smell, but it's a simple way to ensure the existence of 1-1 tables.
+        await update_player_vanilla_stats_async(game, session, player_id, wide_stats, protocol, host, app_id, token)
+    else: # Player exists in DB. Update stats
+        logger.debug(f"update_player_vanilla_stats_async: User exists: {player_id}")
+        for index, stat in enumerate(wide_stats):
+
+            if stats_map[index]["table"] == "" or stats_map[index]["field"] == "":
+                continue
+
+            stats_table_obj: type[DeclarativeBase] = getattr(player, stats_map[index]["table"])
+            setattr(stats_table_obj, stats_map[index]["field"], stat)
+
+        session.add(player)
+        await session.commit()
+
 
 
 # TODO Determine if this should be part of a single function.

--- a/horizon/middleware_api.py
+++ b/horizon/middleware_api.py
@@ -6,7 +6,14 @@ import logging
 
 import requests
 
-logger = logging.getLogger("uvicorn")  # Get the uvicorn logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+stream_handler.setFormatter(formatter)
+logger.addHandler(stream_handler)
+
 
 def authenticate(protocol: str, host: str, username: str, password: str) -> str:
     """
@@ -88,7 +95,7 @@ async def get_all_accounts_async(protocol: str, host: str, app_id: str | int, to
             return []
 
 
-async def get_account_basic_stats_async(protocol: str, host: str, account_id: str | int, app_id: str | int, token: str) -> Optional[dict[str, any]]:
+async def get_account_basic_stats_async(protocol: str, host: str, account_id: str | int, app_id: str | int, token: str) -> dict:
     """
     Makes a request to the Horizon Middleware account API which returns
     all basic stats for a user (including vanilla and custom stats).
@@ -108,7 +115,7 @@ async def get_account_basic_stats_async(protocol: str, host: str, account_id: st
             if response.status == 200:
                 return await response.json()  # Parse the response as JSON if status is OK
             logger.warning(f"get_account_basic_stats got {response.status} from {protocol}://{host}")
-            return []
+            return {}
 
 async def get_players_online(protocol: str, host: str, token: str) -> list[dict[str, any]]:
     """

--- a/horizon/middleware_manager.py
+++ b/horizon/middleware_manager.py
@@ -105,43 +105,55 @@ class UyaOnlineTracker:
     async def refresh_token(self) -> None:
         # Periodically refresh token so we don't get 401
         while True:
-            self._token = await authenticate_async(
-                protocol=self._protocol,
-                host=self._host,
-                username=self._horizon_username,
-                password=self._horizon_password
-            )
+            # Try except so that if the db goes down, it will work when the db comes back online
+            try:
+                self._token = await authenticate_async(
+                    protocol=self._protocol,
+                    host=self._host,
+                    username=self._horizon_username,
+                    password=self._horizon_password
+                )
+            except Exception as e:
+                logger.error("refresh_token failed to update!", exc_info=True)
+
             await asyncio.sleep(self._token_poll_interval)
 
     async def poll_active_online(self) -> None:
         # Poll forever and update internal variable
         while True:
-            self._players_online: list[dict] = await get_players_online(self._protocol, self._host, self._token)
-            self._games_online: list[dict] = await get_active_games(self._protocol, self._host, self._token)
+            # Try except so that if the db goes down, it will work when the db comes back online
+            try:
+                self._players_online: list[dict] = await get_players_online(self._protocol, self._host, self._token)
+                self._games_online: list[dict] = await get_active_games(self._protocol, self._host, self._token)
+            except Exception as e:
+                logger.error("poll_active_online failed to update!", exc_info=True)
 
             await asyncio.sleep(self._players_online_poll_interval)
 
     async def update_recent_stat_changes(self) -> None:
         while True:
-            # API will return all accounts and their stats when they had a stat change in the past 5 minutes (max 60 minutes ago)
-            recent_stats: list[dict] = await get_recent_stats(self._protocol, self._host, self._token)
-            logger.debug(f"update_live_stats: RECENT STATS: {recent_stats}")
+            # Try except so that if the db goes down, it will work when the db comes back online
+            try:
+                # API will return all accounts and their stats when they had a stat change in the past 5 minutes (max 60 minutes ago)
+                recent_stats: list[dict] = await get_recent_stats(self._protocol, self._host, self._token)
+                logger.debug(f"update_live_stats: RECENT STATS: {recent_stats}")
 
-            if len(recent_stats) > 0:
-                async with SessionLocalAsync() as session:
-                    for recent_stat_change in recent_stats:
-                        # For each stat change that we have, update the database.
-                        horizon_account_id:int = recent_stat_change["AccountId"]
+                if len(recent_stats) > 0:
+                    async with SessionLocalAsync() as session:
+                        for recent_stat_change in recent_stats:
+                            # For each stat change that we have, update the database.
+                            horizon_account_id:int = recent_stat_change["AccountId"]
 
-                        # Convert stats dict of StatIdx:StatValue to a list
-                        stats = [0] * 100
-                        for stat_idx, stat_value in recent_stat_change["Stats"].items():
-                            stats[int(stat_idx)-1] = stat_value
+                            # Convert stats dict of StatIdx:StatValue to a list
+                            stats = [0] * 100
+                            for stat_idx, stat_value in recent_stat_change["Stats"].items():
+                                stats[int(stat_idx)-1] = stat_value
 
-                        # Doesn't block the entire backend while updating DB with this players new stats
-                        logger.debug(f"update_live_stats: updating {horizon_account_id}, {stats}")
-                        await update_player_vanilla_stats_async("uya", session, horizon_account_id, stats, self._protocol, self._host, self._horizon_app_id, self._token)
-
+                            # Doesn't block the entire backend while updating DB with this players new stats
+                            logger.debug(f"update_live_stats: updating {horizon_account_id}, {stats}")
+                            await update_player_vanilla_stats_async("uya", session, horizon_account_id, stats, self._protocol, self._host, self._horizon_app_id, self._token)
+            except Exception as e:
+                logger.error("update_recent_stat_changes failed to update!", exc_info=True)
 
             await asyncio.sleep(self._recent_stats_poll_interval)
 
@@ -204,43 +216,52 @@ class DeadlockedOnlineTracker:
     async def refresh_token(self) -> None:
         # Periodically refresh token so we don't get 401
         while True:
-            self._token = await authenticate_async(
-                protocol=self._protocol,
-                host=self._host,
-                username=self._horizon_username,
-                password=self._horizon_password
-            )
+            try:
+                self._token = await authenticate_async(
+                    protocol=self._protocol,
+                    host=self._host,
+                    username=self._horizon_username,
+                    password=self._horizon_password
+                )
+            except Exception as e:
+                logger.error("refresh_token failed to update!", exc_info=True)
+
             await asyncio.sleep(self._token_poll_interval)
 
     async def poll_active_online(self) -> None:
         # Poll forever and update internal variable
         while True:
-            self._players_online: list[dict] = await get_players_online(self._protocol, self._host, self._token)
-            self._games_online: list[dict] = await get_active_games(self._protocol, self._host, self._token)
+            try:
+                self._players_online: list[dict] = await get_players_online(self._protocol, self._host, self._token)
+                self._games_online: list[dict] = await get_active_games(self._protocol, self._host, self._token)
+            except Exception as e:
+                logger.error("poll_active_online failed to update!", exc_info=True)
 
             await asyncio.sleep(self._players_online_poll_interval)
 
     async def update_recent_stat_changes(self) -> None:
         while True:
-            # API will return all accounts and their stats when they had a stat change in the past 5 minutes (max 60 minutes ago)
-            recent_stats: list[dict] = await get_recent_stats(self._protocol, self._host, self._token)
-            logger.debug(f"update_live_stats: RECENT STATS: {recent_stats}")
+            try:
+                # API will return all accounts and their stats when they had a stat change in the past 5 minutes (max 60 minutes ago)
+                recent_stats: list[dict] = await get_recent_stats(self._protocol, self._host, self._token)
+                logger.debug(f"update_live_stats: RECENT STATS: {recent_stats}")
 
-            if len(recent_stats) > 0:
-                async with SessionLocalAsync() as session:
-                    for recent_stat_change in recent_stats:
-                        # For each stat change that we have, update the database.
-                        horizon_account_id:int = recent_stat_change["AccountId"]
+                if len(recent_stats) > 0:
+                    async with SessionLocalAsync() as session:
+                        for recent_stat_change in recent_stats:
+                            # For each stat change that we have, update the database.
+                            horizon_account_id:int = recent_stat_change["AccountId"]
 
-                        # Convert stats dict of StatIdx:StatValue to a list
-                        stats = [0] * 100
-                        for stat_idx, stat_value in recent_stat_change["Stats"].items():
-                            stats[int(stat_idx)-1] = stat_value
+                            # Convert stats dict of StatIdx:StatValue to a list
+                            stats = [0] * 100
+                            for stat_idx, stat_value in recent_stat_change["Stats"].items():
+                                stats[int(stat_idx)-1] = stat_value
 
-                        # Doesn't block the entire backend while updating DB with this players new stats
-                        logger.debug(f"update_live_stats: updating {horizon_account_id}, {stats}")
-                        await update_player_vanilla_stats_async("dl", session, horizon_account_id, stats, self._protocol, self._host, self._horizon_app_id, self._token)
-
+                            # Doesn't block the entire backend while updating DB with this players new stats
+                            logger.debug(f"update_live_stats: updating {horizon_account_id}, {stats}")
+                            await update_player_vanilla_stats_async("dl", session, horizon_account_id, stats, self._protocol, self._host, self._horizon_app_id, self._token)
+            except Exception as e:
+                logger.error("update_recent_stat_changes failed to update!", exc_info=True)
 
             await asyncio.sleep(self._recent_stats_poll_interval)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ psycopg2
 requests
 urllib3
 aiohttp
+asyncpg


### PR DESCRIPTION
Example output on retries:
```
fastapi_app  | 2024-09-25 20:55:08,078 - app.utils.database - WARNING - Function 'update_player_vanilla_stats_async' failed on attempt 1/3: (sqlalchemy.dialects.postgresql.asyncpg.Error) <class 'asyncpg.exceptions.ConnectionDoesNotExistError'>: connection was closed in the middle of operation
fastapi_app  | [SQL: SELECT uya_player.id, uya_player.horizon_id, uya_player.username 
fastapi_app  | FROM uya_player 
fastapi_app  | WHERE uya_player.horizon_id = $1::INTEGER]
fastapi_app  | [parameters: (101628,)]
fastapi_app  | (Background on this error at: https://sqlalche.me/e/20/dbapi)
fastapi_app  | 2024-09-25 20:55:08,078 - app.utils.database - WARNING - Function 'update_player_vanilla_stats_async' rolling back session!
fastapi_app  | 2024-09-25 20:55:10,080 - app.utils.query_helpers - DEBUG - update_player_vanilla_stats_async: 101628 Got options: [<sqlalchemy.orm.strategy_options.Load object at 0xffffa15eb740>, <sqlalchemy.orm.strategy_options.Load object at 0xffffa14e3400>, <sqlalchemy.orm.strategy_options.Load object at 0xffffa412dec0>, <sqlalchemy.orm.strategy_options.Load object at 0xffffa3f3ee80>, <sqlalchemy.orm.strategy_options.Load object at 0xffffa3f3fb00>]
fastapi_app  | 2024-09-25 20:55:10,259 - app.utils.query_helpers - DEBUG - update_player_vanilla_stats_async: Got player: <app.models.uya.uya_player.UyaPlayer object at 0xffffa148d4c0>
```